### PR TITLE
Rename `empty()` to `is_empty()` to follow std.

### DIFF
--- a/src/buf.rs
+++ b/src/buf.rs
@@ -173,7 +173,7 @@ impl Buf {
 
     /// Is buffer is empty. Potentially a little bit faster than
     /// getting `len()`
-    pub fn empty(&self) -> bool {
+    pub fn is_empty(&self) -> bool {
         self.data.is_none()
     }
 


### PR DESCRIPTION
fixes #3

Breaking change.
