### PR TITLE
Remove max buf size

### DIFF
--- a/src/buf.rs
+++ b/src/buf.rs
@@ -68,7 +68,7 @@ impl Buf {
             if self.consumed() > 0 { // let's allocate new slice and move
                 let min_size = old_bytes + bytes;
 
-                let mut vec = Vec::with_capacity(max(min_size, old_cap*2));
+                let mut vec = Vec::with_capacity(max(min_size, old_cap.saturating_mul(2)));
                 let cap = vec.capacity();
                 unsafe { vec.set_len(cap) };
                 copy_memory(&slice[self.consumed()..old_cap - self.remaining()],
@@ -310,7 +310,7 @@ impl Buf {
             return Ok(true);
         }
         if self.remaining() < READ_MIN {
-            if self.capacity() * 2 < max {
+            if self.capacity().saturating_mul(2) < max {
                 // TODO is too large we may never need so big buffer
                 self.reserve(READ_MIN);
             } else {

--- a/src/buf.rs
+++ b/src/buf.rs
@@ -10,11 +10,6 @@ use range::RangeArgument;
 const READ_MIN: usize = 4096;
 const ALLOC_MIN: usize = 16384;
 
-/// Maximum size of buffer allowed.
-/// Note: we assert on this size. Most network servers should set their own
-/// limits to something much smaller.
-pub const MAX_BUF_SIZE: usize = 4294967294; // (1 << 32) - 2;
-
 ///
 /// A buffer object to be used for reading from network
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,5 +34,4 @@ mod buf;
 mod range;
 
 pub use buf::Buf;
-pub use buf::MAX_BUF_SIZE;
 pub use range::RangeArgument;


### PR DESCRIPTION
Changes the capacity to usize and removes MAX_BUF_SIZE.

The latter makes this a breaking change.

Closes #13 