### PR TITLE
Copyedit documentation

### DIFF
--- a/src/range.rs
+++ b/src/range.rs
@@ -1,6 +1,6 @@
 use std::ops::{Range, RangeFrom, RangeTo, RangeFull};
 
-/// Temporary type until the one in stdlib it made stable
+/// Temporary type until the one in stdlib is made stable
 pub enum RangeArgument {
     RangeFrom(usize),
     Range(usize, usize),


### PR DESCRIPTION
Fixes a few typos and rewrites a few sentences for clarity.